### PR TITLE
Går nu att redigera karaktär utan att byta namn

### DIFF
--- a/preferences.xml
+++ b/preferences.xml
@@ -3,5 +3,5 @@
 <project_directory>C:\Users\manso\Desktop</project_directory>
 <window_maximized>false</window_maximized>
 <window_width>1417</window_width>
-<window_height>720</window_height>
+<window_height>562</window_height>
 </preferences>

--- a/src/main/java/com/team34/controller/MainController.java
+++ b/src/main/java/com/team34/controller/MainController.java
@@ -517,14 +517,45 @@ public class MainController {
     private void editCharacter(long uid) {
         Object[] characterData = model.characterManager.getCharacterData(uid);
 
-
         if (view.getEditCharacterPanel().showEditCharacter((String) characterData[0], (String) characterData[1])
                 == EditCharacterDialog.WindowResult.OK
         ) {
-            if (model.characterManager.getCharacter(view.getEditCharacterPanel().getCharacterName()) != null) {
-                view.showDialog("A Character with that name already exists, a character has not been created");
-                return;
+
+
+            if (model.characterManager.getCharacter(view.getEditCharacterPanel().getCharacterName()) == null) {
+                if (characterData[0] != view.getEditCharacterPanel().getCharacterName()) {
+                    model.characterManager.editCharacter(uid,
+                            view.getEditCharacterPanel().getCharacterName(),
+                            view.getEditCharacterPanel().getCharacterAge(),
+                            view.getEditCharacterPanel().getCharacterDescription(),
+                            view.getEditCharacterPanel().getCharacterEvent()
+                    );
+                } else {
+                    view.showDialog("A character with that name already exists, the character has not been edited");
+                    return;
+                }
             }
+
+
+
+             /*
+            if (model.characterManager.getCharacter(view.getEditCharacterPanel().getCharacterName()) == null) {
+                if (characterData[0] != view.getEditCharacterPanel().getCharacterName()) {
+                    model.characterManager.editCharacter(uid,
+                            view.getEditCharacterPanel().getCharacterName(),
+                            view.getEditCharacterPanel().getCharacterAge(),
+                            view.getEditCharacterPanel().getCharacterDescription(),
+                            view.getEditCharacterPanel().getCharacterEvent()
+                    );
+                }else {
+                    view.showDialog("A character with that name already exists, the character has not been edited");
+                    return;
+                }
+
+            }
+
+              */
+
             if (view.getEditCharacterPanel().getCharacterAge() == -1) {
                 WarningDialog.displayWarning("Character's age needs to be a positive digit", "Invalid age");
             } else {


### PR DESCRIPTION
När man redigerade en karaktär utan att byta namn trodde programmet att det var ett upptaget namn. Detta är nu fixat.